### PR TITLE
Add tree map chart to page 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,21 @@ You will get a http link, open this in your browser to see the results. You can 
 ## Resources
 
 * [Dash](https://dash.plot.ly/)
+
+
+# TODO:
+- page1:
+  - add accident columns
+  - e.g. put all accident rows into casualty table
+- page2:
+  - create a detailed graph of specific attribute (maybe just a pie chart or bar chat)
+- page3:
+  - comparison between two attributes
+  - e.g. ternary plot, back-to-back histogram
+- page4:
+  - visualization of attribute info over time
+  - e.g. radial plot / stacked line chart
+
+- final touches:
+  - buttons for ui to go between pages
+  - make graphs look nice

--- a/app.py
+++ b/app.py
@@ -10,6 +10,8 @@ from dash.dependencies import Input, Output
 from jbi100_app.views.stackedplot import Stackedplot
 from jbi100_app.views.twinhistogram import Twinhistogram
 
+import jbi100_app.page1 as page1
+
 use_all_data = True
 
 if __name__ == '__main__':
@@ -19,14 +21,13 @@ if __name__ == '__main__':
     else:
         cdf = test_data()
 
-    # Instantiate custom views
-    plot1 = Stackedplot("Annual costs over time", 'casualty_type', cdf, 'cost (£)')
-    plot2 = Stackedplot("Vehicles over time", 'vehicle_type', vdf, 'total')
-    plot3 = Twinhistogram("Casualty comparison histogram", 'casualty_type', cdf, 7, 'cost (£)')
-    plot4 = Twinhistogram("Vehicle comparison histogram", 'vehicle_type', vdf, 10, 'total')
-    plot5 = Stackedplot("Accidents over time", 'number_of_vehicles', adf, 'total')
-    plot6 = Twinhistogram("Accident comparison histogram", 'did_police_officer_attend_scene_of_accident', adf, 8,
-                          'total')
+    if use_all_data:
+        plot2 = Stackedplot("Vehicles over time", 'vehicle_type', vdf, 'total')
+        plot3 = Twinhistogram("Casualty comparison histogram", 'casualty_type', cdf, 7, 'cost (£)')
+        plot4 = Twinhistogram("Vehicle comparison histogram", 'vehicle_type', vdf, 10, 'total')
+        plot5 = Stackedplot("Accidents over time", 'number_of_vehicles', adf, 'total')
+        plot6 = Twinhistogram("Accident comparison histogram", 'did_police_officer_attend_scene_of_accident', adf, 8,
+                            'total')
 
     app.layout = html.Div(
         id="app-container",
@@ -66,7 +67,7 @@ if __name__ == '__main__':
         ])
     def init_plot(plot_num):
         if plot_num == 1:
-            return plot1
+            return page1.layout()
         elif plot_num == 2:
             return plot2
         elif plot_num == 3:
@@ -78,53 +79,46 @@ if __name__ == '__main__':
         elif plot_num == 6:
             return plot6
 
-    # Define interactions when updating control card values
-    @app.callback(
-        Output(plot1.html_id, "figure"), [
-            Input("select-category-1", "value"),
-        ])
-    def update_plot_1(selected_category):
-        return plot1.update(selected_category)
+    if use_all_data:
+        @app.callback(
+            Output(plot2.html_id, "figure"), [
+                Input("select-category-2", "value"),
+            ])
+        def update_plot_2(selected_category):
+            return plot2.update(selected_category)
 
-    @app.callback(
-        Output(plot2.html_id, "figure"), [
-            Input("select-category-2", "value"),
-        ])
-    def update_plot_2(selected_category):
-        return plot2.update(selected_category)
+        @app.callback(
+            Output(plot3.html_id, "figure"), [
+                Input("select-value-3", "value"),
+                Input("select-category-3", "value"),
+                Input("select-year-3", "value"),
+            ])
+        def update_plot_3(selected_value, selected_category, selected_year):
+            return plot3.update(selected_value, selected_category, selected_year)
 
-    @app.callback(
-        Output(plot3.html_id, "figure"), [
-            Input("select-value-3", "value"),
-            Input("select-category-3", "value"),
-            Input("select-year-3", "value"),
-        ])
-    def update_plot_3(selected_value, selected_category, selected_year):
-        return plot3.update(selected_value, selected_category, selected_year)
+        @app.callback(
+            Output(plot4.html_id, "figure"), [
+                Input("select-value-4", "value"),
+                Input("select-category-4", "value"),
+                Input("select-year-4", "value"),
+            ])
+        def update_plot_4(selected_value, selected_category, selected_year):
+            return plot4.update(selected_value, selected_category, selected_year)
 
-    @app.callback(
-        Output(plot4.html_id, "figure"), [
-            Input("select-value-4", "value"),
-            Input("select-category-4", "value"),
-            Input("select-year-4", "value"),
-        ])
-    def update_plot_4(selected_value, selected_category, selected_year):
-        return plot4.update(selected_value, selected_category, selected_year)
+        @app.callback(
+            Output(plot5.html_id, "figure"), [
+                Input("select-category-5", "value"),
+            ])
+        def update_plot_5(selected_category):
+            return plot5.update(selected_category)
 
-    @app.callback(
-        Output(plot5.html_id, "figure"), [
-            Input("select-category-5", "value"),
-        ])
-    def update_plot_5(selected_category):
-        return plot5.update(selected_category)
-
-    @app.callback(
-        Output(plot6.html_id, "figure"), [
-            Input("select-value-6", "value"),
-            Input("select-category-6", "value"),
-            Input("select-year-6", "value"),
-        ])
-    def update_plot_6(selected_value, selected_category, selected_year):
-        return plot6.update(selected_value, selected_category, selected_year)
+        @app.callback(
+            Output(plot6.html_id, "figure"), [
+                Input("select-value-6", "value"),
+                Input("select-category-6", "value"),
+                Input("select-year-6", "value"),
+            ])
+        def update_plot_6(selected_value, selected_category, selected_year):
+            return plot6.update(selected_value, selected_category, selected_year)
 
     app.run_server(debug=False, dev_tools_ui=False)

--- a/jbi100_app/assets/style.css
+++ b/jbi100_app/assets/style.css
@@ -46,3 +46,17 @@ h5 {
     padding-bottom: 7px;
     border-bottom:  1px solid #ccc;
 }
+
+.inline-control-card > div {
+    /* the left column takes up 1/3 of the screen already */
+    width: 17%;
+    padding-right: 1%;
+    float: left;
+}
+
+/* clear floats from above */
+.inline-control-card::after {
+  content: "";
+  clear: both;
+  display: table;
+}

--- a/jbi100_app/config.py
+++ b/jbi100_app/config.py
@@ -7,6 +7,11 @@ category_list2 = ["accident_year", "vehicle_type", "towing_and_articulation", "v
 # accident
 category_list3 = ["accident_year", "accident_severity", "number_of_vehicles", "number_of_casualties", "day_of_week", "road_type", "speed_limit", "did_police_officer_attend_scene_of_accident", "urban_or_rural_area", "pedestrian_crossing_physical_facilities", "weather_conditions"]
 
+# merged casualties + accidents
+# list(set) is deduplication
+# TODO: speed limit column doesn't work because it has NaN/null values
+category_list4 = sorted(list(set(category_list1 + category_list3)))
+
 # directories for stored .csv files
 casualty_data = 'data/dft-road-casualty-statistics-casualty-1979-2020.csv'
 vehicle_data = 'data/dft-road-casualty-statistics-vehicle-1979-2020.csv'

--- a/jbi100_app/data.py
+++ b/jbi100_app/data.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from time import time
+from functools import cache
 import sys
 from jbi100_app.config import casualty_data, vehicle_data, accident_data
 
@@ -8,7 +9,7 @@ from jbi100_app.config import casualty_data, vehicle_data, accident_data
 # For testing make this higher, for final presentation set it lower.
 SAMPLING_RATE = 20
 
-
+@cache
 def get_data():
     start = time()
     print("Reading the data")
@@ -74,6 +75,7 @@ def get_data():
 
 
 # function that enables faster testing due to less pre-computation
+@cache
 def test_data():
     start = time()
     print("Reading the data")
@@ -103,6 +105,6 @@ def test_data():
     # augment each row with a cost value based on severity
     casualty_df['cost'] = casualty_df.apply(
         lambda row: SAMPLING_RATE * cost_by_year_casualty(row['accident_year'], row['casualty_severity']), axis=1)
-
+    print(f"Done reading data in {time() - start:.2f}s")
     return casualty_df
 

--- a/jbi100_app/page1.py
+++ b/jbi100_app/page1.py
@@ -9,9 +9,9 @@ from jbi100_app.data import test_data
 from jbi100_app.views.stackedplot import Stackedplot
 from jbi100_app.views.treemapchart import TreeMapChart
 
-from jbi100_app.config import category_list1
+from jbi100_app.config import category_list4
 
-cdf = test_data()
+[cdf, _, _] = get_data()
 plot1 = Stackedplot("Annual costs over time", 'casualty_type', cdf, 'cost (£)')
 plotx = TreeMapChart("High-level cost breakdown by casualty")
 plotx_norm = TreeMapChart("Cost normalized by expected frequency by casualty")
@@ -49,7 +49,7 @@ def update_plot_x_norm(*args):
 NONE = "None"
 
 def layout():
-    categories = [NONE] + category_list1
+    categories = [NONE] + category_list4
     def tree_level(id):
         return html.Div(children=[
             html.Label("Level " + str(id)),

--- a/jbi100_app/page1.py
+++ b/jbi100_app/page1.py
@@ -1,0 +1,83 @@
+from jbi100_app.data import get_data, test_data
+from dash import html
+import plotly.express as px
+from dash.dependencies import Input, Output
+from jbi100_app.main import app
+from dash import dcc, html
+
+from jbi100_app.data import test_data
+from jbi100_app.views.stackedplot import Stackedplot
+from jbi100_app.views.treemapchart import TreeMapChart
+
+from jbi100_app.config import category_list1
+
+cdf = test_data()
+plot1 = Stackedplot("Annual costs over time", 'casualty_type', cdf, 'cost (£)')
+plotx = TreeMapChart("High-level cost breakdown by casualty")
+plotx_norm = TreeMapChart("Cost normalized by expected frequency by casualty")
+
+# Define interactions when updating control card values
+@app.callback(
+    Output(plot1.html_id, "figure"), [
+        Input("select-category-1", "value"),
+    ])
+def update_plot_1(selected_category):
+    return plot1.update(selected_category)
+
+@app.callback(
+    Output(plotx.html_id, "figure"), [
+        Input("plotx-level-1", "value"),
+        Input("plotx-level-2", "value"),
+        Input("plotx-level-3", "value"),
+        Input("plotx-level-4", "value"),
+    ])
+def update_plot_x(*args):
+    tree_levels = [level for level in args if level != NONE]
+    return plotx.update(cdf, tree_levels)
+
+@app.callback(
+    Output(plotx_norm.html_id, "figure"), [
+        Input("plotx-level-1", "value"),
+        Input("plotx-level-2", "value"),
+        Input("plotx-level-3", "value"),
+        Input("plotx-level-4", "value"),
+    ])
+def update_plot_x_norm(*args):
+    tree_levels = [level for level in args if level != NONE]
+    return plotx_norm.update(cdf, tree_levels, True)
+
+NONE = "None"
+
+def layout():
+    categories = [NONE] + category_list1
+    def tree_level(id):
+        return html.Div(children=[
+            html.Label("Level " + str(id)),
+            dcc.Dropdown(
+                id="plotx-level-" + str(id),
+                options=[{"label": i, "value": i} for i in categories],
+                # first level is "severity"
+                value=categories[6] if id == 1 else categories[0],
+            ),
+        ])
+
+    plotx_menu = html.Div(
+        className="inline-control-card",
+        children=[
+            tree_level(1),
+            tree_level(2),
+            tree_level(3),
+            tree_level(4),
+        ], style={"textAlign": "float-left"}
+    )
+
+    return html.Div(
+        className="center-plots",
+        children=[
+            html.Div(children=["Home page plots :)"]),
+            plotx_menu,
+            plotx,
+            plotx_norm,
+            plot1,
+        ],
+    )

--- a/jbi100_app/views/treemapchart.py
+++ b/jbi100_app/views/treemapchart.py
@@ -1,0 +1,66 @@
+from dash import dcc, html
+import plotly.graph_objects as go
+import plotly.express as px
+import pandas as pd
+import time
+
+from jbi100_app.views.shared import field_to_title
+
+
+# Treemap chart of multiple attributes, area determined by cost
+# https://plotly.com/python/treemaps/
+class TreeMapChart(html.Div):
+    def __init__(self, name, value_label='cost'):
+        self.html_id = name.lower().replace(" ", "-")
+        self.value_label = value_label
+        self.feature_y = 'cost'
+
+        # Equivalent to `html.Div([...])`
+        super().__init__(
+            className="graph_card",
+            children=[
+                html.H6(name),
+                dcc.Graph(id=self.html_id)
+            ],
+        )
+
+    # Value feature for colors, category feature for bars
+    def update(self, df, category_features, normalize=False):
+        print("start: updating plot")
+        start = time.time()
+        if normalize:
+            # a normalized version that makes the squares proportional to how often they are in df
+            # i.e. make uncommon entries bigger, more common smaller
+            # thus it is easier to see relative costs, removed from sample size
+            # a large size tells you, GIVEN such a category occurred, it is relatively more costly
+            df['norm_factor'] = [1] * len(df)
+            for cat in category_features:
+                freqs = dict(df[cat].value_counts())
+                # scale up / down norm_cost depending on the right frequency
+                total = sum(freqs.values())
+                # expected number per class if they were uniformly distributed
+                expectation = 1 / len(freqs)
+                for key in freqs:
+                    ratio = freqs[key] / total
+                    # ratio * correction = expectation
+                    correction = expectation / ratio
+                    df.loc[df[cat] == key, 'norm_factor'] *= correction
+            df['norm_cost'] = df.apply(
+                lambda row: row['norm_factor'] * row[self.feature_y], axis=1)
+            df.loc[:, 'norm_cost'] /= df['norm_cost'].sum()
+
+            fig = px.treemap(df,
+                            path=[px.Constant("all")] + category_features,
+                            values='norm_cost',
+                            ) 
+            # df.drop("norm_factor")
+            # df.drop("norm_cost")
+        else:
+            fig = px.treemap(df,
+                            path=[px.Constant("all")] + category_features,
+                            values=self.feature_y,
+                            ) 
+        fig.update_layout(margin = dict(t=50, l=25, r=25, b=25))
+
+        print(f"done: updating {self.html_id} plot in {time.time() - start:.2f}s")
+        return fig


### PR DESCRIPTION
Adds a pair of tree map charts to page 1.

I feel like this is a good way to explore the attributes at a high level.

The two charts are paired, changing items in the menu changes both at the same time:
 - the first displays absolute costs
 - the second displays relative costs, i.e. the cost divided by the expected probability of that category. 
    - a large size tells you, *given* such a category occurred, it is relatively more costly (see code comments)

![Screen Shot 2022-01-20 at 10 11 30 PM](https://user-images.githubusercontent.com/2406051/150423293-cb948b77-f2e0-4672-a531-7fa7ad399832.png)
![Screen Shot 2022-01-20 at 10 09 10 PM](https://user-images.githubusercontent.com/2406051/150423295-279560cf-68a7-44e6-b48d-27980b7f2dbd.png)
